### PR TITLE
Fix cli.md

### DIFF
--- a/setup/borg/cli.md
+++ b/setup/borg/cli.md
@@ -187,45 +187,40 @@ If you keep your repos with BorgBase you can copy a pre-made Borgmatic confirgur
 
 ```
 # Updated ~/.config/borgmatic/config.yaml
-location:
-    source_directories:
-        - ~/Desktop
-        - ~/Documents
-        - ~/Pictures
+source_directories:
+    - ~/Desktop
+    - ~/Documents
+    - ~/Pictures
 
-    # one_file_system: true
+# one_file_system: true
 
-    repositories:
-        - ssh://mmvz9gp4@mmvz9gp4.repo.borgbase.com/./repo
+repositories:
+    - path: ssh://mmvz9gp4@mmvz9gp4.repo.borgbase.com/./repo
 
-    exclude_caches: true
+exclude_caches: true
 
-storage:
-    compression: auto,zstd
-    encryption_passphrase: CHANGE ME!!
-    archive_name_format: '{hostname}-{now}'
+compression: auto,zstd
+encryption_passphrase: CHANGE ME!!
+archive_name_format: '{hostname}-{now}'
 
-    # Number of times to retry a failing backup
-    # Needs recent Borgmatic version
-    retries: 5
-    retry_wait: 5
+# Number of times to retry a failing backup
+# Needs recent Borgmatic version
+retries: 5
+retry_wait: 5
 
-retention:
-    keep_daily: 3
-    keep_weekly: 4
-    keep_monthly: 12
+keep_daily: 3
+keep_weekly: 4
+keep_monthly: 12
 
-consistency:
-    checks:
-      - disabled
-      # Uncomment to regularly read all repo data
-      # Needs recent Borgmatic version
-      # - name: repository
-      #   frequency: 4 weeks
-      # - name: archives
-      #   frequency: 8 weeks
+# Uncomment to regularly read all repo data
+# Needs recent Borgmatic version
+# checks:
+#   - name: repository
+#     frequency: 4 weeks
+#   - name: archives
+#     frequency: 8 weeks
 
-    check_last: 3
+check_last: 3
 ```
 
 Let's look at the major sections of this file one-by-one. Since the format is YAML, white-space, like spaces is important.

--- a/setup/borg/cli.md
+++ b/setup/borg/cli.md
@@ -232,7 +232,7 @@ Let's look at the major sections of this file one-by-one. Since the format is YA
 
 - `source_directories`:  The list of folders you actually want to back up. You can always add more source folders later. They will simply be added.
 - `repositories`: The address of your backup repo.
-- `encryption_passphrase`: The password to access the repo, as set in step 4.
+- `encryption_passphrase`: The password to access the repo, as set in step 5.
 - `retention`: Determines how many snapshots Borg will keep.
 
 Once you are happy with the options, save the file and initialize your repository, like you would with Borg only:
@@ -260,7 +260,7 @@ $ borgmatic --verbosity 2
 
 Depending on your backup folder size, this may take a while. After Borgmatic is done, you can view the available snapshots and some statistics.
 ```
-$ borgmatic --list --info
+$ borgmatic rinfo
 ```
 
 After a few seconds you should get some output similar to this:


### PR DESCRIPTION
The password is created in step 5, but in step 6 it was mentioned to be created in step 4.
`borgmatic --list --info`  does not appear to be a valid borgmatic command (I'm using the current stable version 1.8.2), but `borgmatic rinfo` provides the desired output.