### PR TITLE
Fix all checks being enabled by default in setup example for borgmatic >= 1.8

### DIFF
--- a/setup/borg/cli.md
+++ b/setup/borg/cli.md
@@ -246,6 +246,8 @@ keep_daily: 3
 keep_weekly: 4
 keep_monthly: 12
 
+checks:
+  - name: disabled
 # Uncomment to regularly read all repo data
 # Needs recent Borgmatic version
 # checks:


### PR DESCRIPTION
I noticed that I made a mistake in #27. When not providing any options for checks, borgmatic runs full-repository and per-archive checks. Details can be found [here](https://torsion.org/borgmatic/docs/how-to/deal-with-very-large-backups/#consistency-check-configuration). I modified the example for borgmatic >= 1.8 to have the same behavior as the version for borgmatic <= 1.7.
